### PR TITLE
Using protected setUp, not public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php :
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/tests/ComparationsTest.php
+++ b/tests/ComparationsTest.php
@@ -13,7 +13,7 @@ class ComparationsTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 

--- a/tests/IndexingTest.php
+++ b/tests/IndexingTest.php
@@ -12,7 +12,7 @@ class IndexingTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }

--- a/tests/OperatorsTest.php
+++ b/tests/OperatorsTest.php
@@ -12,7 +12,7 @@ class OperatorsTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -11,7 +11,7 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         $this->booleanList = new np_array([true, false, true, null]);

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use numphp\np_array;
 use numphp\Random\Random;
 
 class RandomTest extends \PHPUnit\Framework\TestCase

--- a/tests/SetItemsTest.php
+++ b/tests/SetItemsTest.php
@@ -12,7 +12,7 @@ class SetItemsTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 

--- a/tests/ShapingTest.php
+++ b/tests/ShapingTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use numphp\np_array;
-use numphp\Shaping\Reshaper;
 
 class ShapingTest extends \PHPUnit\Framework\TestCase
 {
@@ -12,7 +11,7 @@ class ShapingTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         $this->listEven = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use numphp\np_array;
-use numphp\Slicing\Slice;
 
 class SliceTest extends \PHPUnit\Framework\TestCase
 {
@@ -12,7 +11,7 @@ class SliceTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }

--- a/tests/StatisticsTest.php
+++ b/tests/StatisticsTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use numphp\np_array;
-use numphp\Statistics\Statistics;
 
 class StatisticsTest extends \PHPUnit\Framework\TestCase
 {
@@ -12,7 +11,7 @@ class StatisticsTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->list = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         $this->listEven = new np_array([0, 1, 2, 3, 4, 5, 6, 7, 8]);
@@ -72,7 +71,7 @@ class StatisticsTest extends \PHPUnit\Framework\TestCase
     /**
      * Matrix
      */
-    
+
     public function testMatrixMax()
     {
         $res = $this->matrix->max();


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `setUp` method should be `protected`, not `public`.
- Add `php-7.3` support.
- Remove unused namespace classes